### PR TITLE
Add integration coverage for kernel plan flows

### DIFF
--- a/STATE.MD
+++ b/STATE.MD
@@ -10,14 +10,17 @@
   - Await event waiting on schemas and resuming on DomainEvents.
   - Guards blocking downstream steps when false.
   - Raise event producing DomainEvents.
-- `crates/aos-kernel/src/world.rs` still only has the original smoke test covering reducer → plan → effect happy path. No integration tests exist yet for receipts, waiting events, or reducer receipt handling.
+
+### Tests in place (integration level)
+- `crates/aos-kernel/src/world.rs` now has:
+  - Smoke test for reducer → plan → effect happy path.
+  - Plan receipt routing coverage ensuring receipts resume waiting plans and populate bindings.
+  - Plan event wake-up coverage ensuring only matching schemas resume queued plans.
+  - Guarded branching coverage verifying guarded effects complete only on the true path and remain pending otherwise.
+  - Raised event propagation coverage validating plan-raised events reach reducers through the scheduler.
 
 ### Tests to add next (integration level)
-1. **Plan receipt routing**: plan emits effect, waits, adapter receipt via `Kernel::handle_receipt` resumes the plan; verify bind var populated, pending_receipts cleared.
-2. **Plan event wake-up**: multiple plan instances waiting on different schemas; deliver DomainEvent matching one schema and ensure only that plan is re-queued/run.
-3. **Reducer receipt delivery**: (once reducer micro-effect receipt flow is implemented) convert receipts into DomainEvents for reducers.
-4. **Guarded branching end-to-end**: manifest plan with guard false vs true; assert effect queue outcomes and plan completion.
-5. **Raised event propagation**: plan raises an event that is routed to reducers via scheduler.
+1. **Reducer receipt delivery**: (once reducer micro-effect receipt flow is implemented) convert receipts into DomainEvents for reducers and assert reducer/event routing.
 
 Plan is to create helper builders (reducer module, manifest with plan, plan inputs) so tests stay concise. Tests should live either alongside `world.rs` (current module) or under `crates/aos-kernel/tests/` if they grow.
 


### PR DESCRIPTION
## Summary
- add kernel integration tests covering plan receipt routing, event wake-ups, guarded branching, and raised event propagation
- update STATE.MD to reflect the new integration test coverage status

## Testing
- cargo test *(fails: aos-cbor canonical hash mismatch in existing test suite)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ef87ef67c832d9548f60b976c91ec)