### PR TITLE
Typed Bus + Event-Family Dispatch

### DIFF
--- a/crates/aos-air-types/src/model.rs
+++ b/crates/aos-air-types/src/model.rs
@@ -515,10 +515,8 @@ pub enum PlanStepKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PlanStepRaiseEvent {
-    pub reducer: Name,
-    pub event: ExprOrValue,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub key: Option<Expr>,
+    pub event: SchemaRef,
+    pub value: ExprOrValue,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/aos-cbor/src/lib.rs
+++ b/crates/aos-cbor/src/lib.rs
@@ -173,7 +173,7 @@ mod tests {
             ),
             (
                 "spec/schemas/defplan.schema.json",
-                "sha256:17e4c5c9eec58d537c4e95b340c5afd046228eb45b4240a936b89d06fb58b3a5",
+                "sha256:524e85de0526b663db63442c48359be53d686c1186da85ef14b7d8887d0c593f",
             ),
             (
                 "spec/schemas/defcap.schema.json",

--- a/crates/aos-examples/src/retry_backoff.rs
+++ b/crates/aos-examples/src/retry_backoff.rs
@@ -133,6 +133,7 @@ fn synthesize_timer_receipts(kernel: &mut Kernel<FsStore>) -> Result<()> {
                 signature: vec![0; 64],
             };
             kernel.handle_receipt(receipt)?;
+            kernel.tick_until_idle()?;
         }
         safety += 1;
         ensure!(safety < 16, "safety trip: too many retry cycles");

--- a/crates/aos-examples/src/retry_backoff.rs
+++ b/crates/aos-examples/src/retry_backoff.rs
@@ -6,13 +6,14 @@ use anyhow::{Result, ensure};
 use aos_effects::{EffectKind as EffectsEffectKind, EffectReceipt, ReceiptStatus};
 use aos_kernel::Kernel;
 use aos_store::FsStore;
+use aos_wasm_sdk::aos_variant;
 use serde::{Deserialize, Serialize};
 use serde_cbor;
 
 use crate::example_host::{ExampleHost, HarnessConfig};
 
 const REDUCER_NAME: &str = "demo/RetrySM@1";
-const START_EVENT_SCHEMA: &str = "demo/StartWork@1";
+const EVENT_SCHEMA: &str = "demo/RetryEvent@1";
 const MODULE_CRATE: &str = "examples/08-retry-backoff/reducer";
 const ADAPTER_ID: &str = "adapter.timer.fake";
 
@@ -23,6 +24,14 @@ struct StartWork {
     max_attempts: u32,
     base_delay_ms: u64,
     now_ns: u64,
+}
+
+aos_variant! {
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    enum RetryEvent {
+        #[serde(rename = "start")]
+        Start(StartWork),
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -63,7 +72,7 @@ pub fn run(example_root: &Path) -> Result<()> {
         example_root,
         assets_root: None,
         reducer_name: REDUCER_NAME,
-        event_schema: START_EVENT_SCHEMA,
+        event_schema: EVENT_SCHEMA,
         module_crate: MODULE_CRATE,
     })?;
 
@@ -79,7 +88,7 @@ pub fn run(example_root: &Path) -> Result<()> {
         "     start req_id={} max_attempts={} base_delay_ms={}",
         start.req_id, start.max_attempts, start.base_delay_ms
     );
-    host.send_event(&start)?;
+    host.send_event(&RetryEvent::Start(start))?;
 
     synthesize_timer_receipts(host.kernel_mut())?;
 

--- a/crates/aos-host/src/host.rs
+++ b/crates/aos-host/src/host.rs
@@ -420,8 +420,8 @@ impl<S: Store + 'static> WorldHost<S> {
     /// This is the correct way to fire timers in daemon mode. The kernel will:
     /// 1. Remove context from `pending_reducer_receipts`
     /// 2. Record receipt in journal
-    /// 3. Build a reducer receipt event (wrapping `sys/TimerFired@1`) via `build_reducer_receipt_event()`
-    /// 4. Push reducer event to scheduler
+    /// 3. Build a `sys/TimerFired@1` receipt event via `build_reducer_receipt_event()`
+    /// 4. Route/wrap at dispatch and push reducer event to scheduler
     ///
     /// Returns the number of timers fired.
     pub fn fire_due_timers(&mut self, scheduler: &mut TimerScheduler) -> Result<usize, HostError> {

--- a/crates/aos-host/src/host.rs
+++ b/crates/aos-host/src/host.rs
@@ -420,7 +420,7 @@ impl<S: Store + 'static> WorldHost<S> {
     /// This is the correct way to fire timers in daemon mode. The kernel will:
     /// 1. Remove context from `pending_reducer_receipts`
     /// 2. Record receipt in journal
-    /// 3. Build `sys/TimerFired@1` via `build_reducer_receipt_event()`
+    /// 3. Build a reducer receipt event (wrapping `sys/TimerFired@1`) via `build_reducer_receipt_event()`
     /// 4. Push reducer event to scheduler
     ///
     /// Returns the number of timers fired.

--- a/crates/aos-host/tests/control_governance.rs
+++ b/crates/aos-host/tests/control_governance.rs
@@ -2,7 +2,7 @@
 
 use aos_host::WorldHost;
 use aos_host::config::HostConfig;
-use aos_host::fixtures::{self, TestWorld};
+use helpers::fixtures::{self, TestWorld};
 use aos_host::manifest_loader::manifest_patch_from_loaded;
 use aos_host::modes::daemon::{ControlMsg, WorldDaemon};
 use aos_kernel::Kernel;

--- a/crates/aos-host/tests/control_patchdoc.rs
+++ b/crates/aos-host/tests/control_patchdoc.rs
@@ -6,7 +6,7 @@ use aos_cbor::Hash;
 use aos_host::WorldHost;
 use aos_host::config::HostConfig;
 use aos_host::control::{ControlClient, ControlMode, ControlServer, RequestEnvelope};
-use aos_host::fixtures::{self, TestStore};
+use helpers::fixtures::{self, TestStore};
 use aos_host::modes::daemon::WorldDaemon;
 use aos_kernel::Kernel;
 use aos_kernel::journal::mem::MemJournal;

--- a/crates/aos-host/tests/daemon_integration.rs
+++ b/crates/aos-host/tests/daemon_integration.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aos_host::config::HostConfig;
-use aos_host::fixtures::{self, TestStore};
+use helpers::fixtures::{self, START_SCHEMA, TestStore};
 use aos_host::modes::daemon::{ControlMsg, WorldDaemon};
 use aos_host::{ExternalEvent, WorldHost};
 use aos_kernel::Kernel;
@@ -37,15 +37,14 @@ async fn daemon_fires_timer_and_routes_event() {
 
     // Kick off the reducer that emits timer.set.
     let start_value = serde_cbor::to_vec(&serde_json::json!({
-        "$tag": "Start",
-        "$value": { "id": "t1" }
+        "id": "t1"
     }))
     .unwrap();
     let (resp_tx, resp_rx) = oneshot::channel();
     control_tx
         .send(ControlMsg::EventSend {
             event: ExternalEvent::DomainEvent {
-                schema: "com.acme/TimerEvent@1".into(),
+                schema: START_SCHEMA.into(),
                 value: start_value,
                 key: None,
             },

--- a/crates/aos-host/tests/daemon_integration.rs
+++ b/crates/aos-host/tests/daemon_integration.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aos_host::config::HostConfig;
-use aos_host::fixtures::{self, START_SCHEMA, TestStore};
+use aos_host::fixtures::{self, TestStore};
 use aos_host::modes::daemon::{ControlMsg, WorldDaemon};
 use aos_host::{ExternalEvent, WorldHost};
 use aos_kernel::Kernel;
@@ -36,12 +36,16 @@ async fn daemon_fires_timer_and_routes_event() {
     let handle = tokio::spawn(async move { (daemon.run().await, daemon) });
 
     // Kick off the reducer that emits timer.set.
-    let start_value = serde_cbor::to_vec(&serde_json::json!({ "id": "t1" })).unwrap();
+    let start_value = serde_cbor::to_vec(&serde_json::json!({
+        "$tag": "Start",
+        "$value": { "id": "t1" }
+    }))
+    .unwrap();
     let (resp_tx, resp_rx) = oneshot::channel();
     control_tx
         .send(ControlMsg::EventSend {
             event: ExternalEvent::DomainEvent {
-                schema: START_SCHEMA.into(),
+                schema: "com.acme/TimerEvent@1".into(),
                 value: start_value,
                 key: None,
             },

--- a/crates/aos-host/tests/governance_integration.rs
+++ b/crates/aos-host/tests/governance_integration.rs
@@ -125,12 +125,7 @@ fn patch_hash_is_identical_for_sugar_and_canonical_plans() {
             .iter()
             .map(|e| e.effect.clone()),
     );
-    normalize_plan_literals(
-        &mut canonical_plan,
-        &builtin_schema_index(),
-        &HashMap::new(),
-        &effect_catalog,
-    )
+    normalize_plan_literals(&mut canonical_plan, &builtin_schema_index(), &effect_catalog)
     .expect("normalize canonical plan");
 
     let sugar_patch = plan_patch(sugar_plan);

--- a/crates/aos-host/tests/helpers.rs
+++ b/crates/aos-host/tests/helpers.rs
@@ -83,15 +83,14 @@ pub fn fulfillment_manifest(store: &Arc<TestStore>) -> aos_kernel::manifest::Loa
             PlanStep {
                 id: "raise".into(),
                 kind: PlanStepKind::RaiseEvent(PlanStepRaiseEvent {
-                    reducer: result_module.name.clone(),
-                    event: Expr::Record(ExprRecord {
+                    event: result_event_schema.clone(),
+                    value: Expr::Record(ExprRecord {
                         record: IndexMap::from([(
                             "value".into(),
                             Expr::Const(ExprConst::Int { int: 9 }),
                         )]),
                     })
                     .into(),
-                    key: None,
                 }),
             },
             PlanStep {
@@ -236,9 +235,8 @@ pub fn await_event_manifest(store: &Arc<TestStore>) -> aos_kernel::manifest::Loa
             PlanStep {
                 id: "raise".into(),
                 kind: PlanStepKind::RaiseEvent(PlanStepRaiseEvent {
-                    reducer: result_module.name.clone(),
-                    key: None,
-                    event: Expr::Record(ExprRecord {
+                    event: result_event_schema.clone(),
+                    value: Expr::Record(ExprRecord {
                         record: IndexMap::from([(
                             "value".into(),
                             Expr::Const(ExprConst::Int { int: 5 }),

--- a/crates/aos-host/tests/journal_integration.rs
+++ b/crates/aos-host/tests/journal_integration.rs
@@ -76,8 +76,12 @@ fn reducer_timer_receipt_replays_from_journal() {
     let store = fixtures::new_mem_store();
     let manifest = timer_manifest(&store);
     let mut world = TestWorld::with_store(store.clone(), manifest).unwrap();
+    let start_event = serde_json::json!({
+        "$tag": "Start",
+        "$value": { "id": "timer" }
+    });
     world
-        .submit_event_result(START_SCHEMA, &serde_json::json!({ "id": "timer" }))
+        .submit_event_result("com.acme/TimerEvent@1", &start_event)
         .expect("submit start event");
     world.tick_n(1).unwrap();
 

--- a/crates/aos-host/tests/journal_integration.rs
+++ b/crates/aos-host/tests/journal_integration.rs
@@ -1,7 +1,7 @@
 use aos_air_exec::Value as ExprValue;
 use aos_effects::builtins::TimerSetReceipt;
 use aos_effects::{EffectReceipt, ReceiptStatus};
-use aos_host::fixtures::{self, START_SCHEMA, TestWorld};
+use helpers::fixtures::{self, START_SCHEMA, TestWorld};
 use aos_kernel::journal::fs::FsJournal;
 use aos_kernel::journal::mem::MemJournal;
 use aos_kernel::journal::{IntentOriginRecord, JournalKind, JournalRecord};
@@ -76,14 +76,10 @@ fn reducer_timer_receipt_replays_from_journal() {
     let store = fixtures::new_mem_store();
     let manifest = timer_manifest(&store);
     let mut world = TestWorld::with_store(store.clone(), manifest).unwrap();
-    let start_event = serde_json::json!({
-        "$tag": "Start",
-        "$value": { "id": "timer" }
-    });
     world
-        .submit_event_result("com.acme/TimerEvent@1", &start_event)
+        .submit_event_result(START_SCHEMA, &fixtures::start_event("timer"))
         .expect("submit start event");
-    world.tick_n(1).unwrap();
+    world.tick_n(2).unwrap();
 
     let effect = world.drain_effects().pop().expect("timer effect");
     let receipt = EffectReceipt {

--- a/crates/aos-host/tests/keyed_reducer_integration.rs
+++ b/crates/aos-host/tests/keyed_reducer_integration.rs
@@ -1,9 +1,12 @@
 #![cfg(feature = "test-fixtures")]
 
+#[path = "helpers.rs"]
+mod helpers;
+
 use std::sync::Arc;
 
 use aos_cbor::Hash;
-use aos_host::fixtures::{self, TestStore};
+use helpers::fixtures::{self, TestStore};
 use aos_kernel::Kernel;
 use aos_kernel::cell_index::CellIndex;
 use aos_kernel::journal::mem::MemJournal;

--- a/crates/aos-host/tests/object_catalog_integration.rs
+++ b/crates/aos-host/tests/object_catalog_integration.rs
@@ -14,13 +14,16 @@
 
 #![cfg(feature = "test-fixtures")]
 
+#[path = "helpers.rs"]
+mod helpers;
+
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use aos_air_types::{
     builtins, plan_literals::SchemaIndex, value_normalize::normalize_cbor_by_name,
 };
-use aos_host::fixtures::{self, TestStore};
+use helpers::fixtures::{self, TestStore};
 use aos_kernel::Kernel;
 use aos_kernel::journal::OwnedJournalEntry;
 use aos_kernel::journal::mem::MemJournal;

--- a/crates/aos-host/tests/snapshot_integration.rs
+++ b/crates/aos-host/tests/snapshot_integration.rs
@@ -1,10 +1,11 @@
 use aos_air_exec::Value as ExprValue;
 use aos_air_types::{
-    DefPolicy, EffectKind as AirEffectKind, OriginKind, PolicyDecision, PolicyMatch, PolicyRule,
+    DefPolicy, DefSchema, EffectKind as AirEffectKind, OriginKind, PolicyDecision, PolicyMatch,
+    PolicyRule, ReducerAbi,
 };
 use aos_effects::builtins::TimerSetReceipt;
 use aos_effects::{EffectReceipt, ReceiptStatus};
-use aos_host::fixtures::{self, START_SCHEMA, TestWorld};
+use helpers::fixtures::{self, START_SCHEMA, TestWorld};
 use aos_kernel::Kernel;
 use aos_kernel::error::KernelError;
 use aos_kernel::journal::fs::FsJournal;
@@ -145,8 +146,8 @@ fn plan_snapshot_resumes_after_event() {
     world
         .submit_event_result(START_SCHEMA, &input)
         .expect("submit start event");
-    world.tick_n(1).unwrap();
-    world.tick_n(1).unwrap();
+    world.tick_n(2).unwrap();
+    world.tick_n(2).unwrap();
 
     world.kernel.create_snapshot().unwrap();
     let entries = world.kernel.dump_journal().unwrap();
@@ -176,14 +177,10 @@ fn reducer_timer_snapshot_resumes_on_receipt() {
     let manifest = timer_manifest(&store);
     let mut world = TestWorld::with_store(store.clone(), manifest).unwrap();
 
-    let start_event = serde_json::json!({
-        "$tag": "Start",
-        "$value": fixtures::start_event("timer"),
-    });
     world
-        .submit_event_result("com.acme/TimerEvent@1", &start_event)
+        .submit_event_result(START_SCHEMA, &fixtures::start_event("timer"))
         .expect("submit start event");
-    world.tick_n(1).unwrap();
+    world.tick_n(2).unwrap();
 
     let effect = world
         .drain_effects()
@@ -282,7 +279,7 @@ fn fs_store_and_journal_restore_snapshot() {
 }
 
 fn fs_persistent_manifest(store: &Arc<FsStore>) -> aos_kernel::manifest::LoadedManifest {
-    let reducer = fixtures::stub_reducer_module(
+    let mut reducer = fixtures::stub_reducer_module(
         store,
         "com.acme/SimpleFs@1",
         &ReducerOutput {
@@ -292,14 +289,24 @@ fn fs_persistent_manifest(store: &Arc<FsStore>) -> aos_kernel::manifest::LoadedM
             ann: None,
         },
     );
+    reducer.abi.reducer = Some(ReducerAbi {
+        state: fixtures::schema("com.acme/SimpleFsState@1"),
+        event: fixtures::schema(START_SCHEMA),
+        annotations: None,
+        effects_emitted: vec![],
+        cap_slots: Default::default(),
+    });
     let routing = vec![fixtures::routing_event(START_SCHEMA, &reducer.name)];
     let mut loaded = fixtures::build_loaded_manifest(vec![], vec![], vec![reducer], routing);
     fixtures::insert_test_schemas(
         &mut loaded,
-        vec![fixtures::def_text_record_schema(
-            START_SCHEMA,
-            vec![("id", fixtures::text_type())],
-        )],
+        vec![
+            fixtures::def_text_record_schema(START_SCHEMA, vec![("id", fixtures::text_type())]),
+            DefSchema {
+                name: "com.acme/SimpleFsState@1".into(),
+                ty: fixtures::text_type(),
+            },
+        ],
     );
     loaded
 }

--- a/crates/aos-host/tests/snapshot_integration.rs
+++ b/crates/aos-host/tests/snapshot_integration.rs
@@ -176,8 +176,12 @@ fn reducer_timer_snapshot_resumes_on_receipt() {
     let manifest = timer_manifest(&store);
     let mut world = TestWorld::with_store(store.clone(), manifest).unwrap();
 
+    let start_event = serde_json::json!({
+        "$tag": "Start",
+        "$value": fixtures::start_event("timer"),
+    });
     world
-        .submit_event_result(START_SCHEMA, &fixtures::start_event("timer"))
+        .submit_event_result("com.acme/TimerEvent@1", &start_event)
         .expect("submit start event");
     world.tick_n(1).unwrap();
 

--- a/crates/aos-host/tests/testhost_integration.rs
+++ b/crates/aos-host/tests/testhost_integration.rs
@@ -3,6 +3,9 @@
 //! These tests demonstrate the TestHost API with programmatically built manifests,
 //! mirroring the pattern used by examples/00-counter and similar.
 
+#[path = "helpers.rs"]
+mod helpers;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -12,7 +15,7 @@ use aos_air_types::{
     TypeVariant, catalog::EffectCatalog,
 };
 use aos_effects::{EffectReceipt, ReceiptStatus};
-use aos_host::fixtures::{self, TestStore};
+use helpers::fixtures::{self, TestStore};
 use aos_host::testhost::TestHost;
 use aos_kernel::LoadedManifest;
 use aos_wasm_abi::{ReducerEffect, ReducerOutput};
@@ -365,14 +368,38 @@ async fn testhost_with_fixtures_build_loaded_manifest() {
         effects: vec![],
         ann: None,
     };
-    let module = fixtures::stub_reducer_module(&store, "test/Reducer@1", &output);
+    let mut module = fixtures::stub_reducer_module(&store, "test/Reducer@1", &output);
+    module.abi.reducer = Some(ReducerAbi {
+        state: SchemaRef::new("test/State@1").unwrap(),
+        event: SchemaRef::new("test/Event@1").unwrap(),
+        annotations: None,
+        effects_emitted: vec![],
+        cap_slots: IndexMap::new(),
+    });
 
     // Build manifest using fixtures helper
-    let loaded = fixtures::build_loaded_manifest(
+    let mut loaded = fixtures::build_loaded_manifest(
         vec![],       // no plans
         vec![],       // no triggers
         vec![module], // one reducer
         vec![fixtures::routing_event("test/Event@1", "test/Reducer@1")],
+    );
+    fixtures::insert_test_schemas(
+        &mut loaded,
+        vec![
+            DefSchema {
+                name: "test/State@1".into(),
+                ty: TypeExpr::Record(TypeRecord {
+                    record: IndexMap::new(),
+                }),
+            },
+            DefSchema {
+                name: "test/Event@1".into(),
+                ty: TypeExpr::Record(TypeRecord {
+                    record: IndexMap::new(),
+                }),
+            },
+        ],
     );
 
     let mut host = TestHost::from_loaded_manifest(store, loaded).unwrap();

--- a/crates/aos-kernel/src/error.rs
+++ b/crates/aos-kernel/src/error.rs
@@ -20,14 +20,6 @@ pub enum KernelError {
     ReceiptDecode(String),
     #[error("unsupported reducer receipt kind '{0}'")]
     UnsupportedReducerReceipt(String),
-    #[error(
-        "reducer receipt schema mismatch (event='{reducer_event_schema}', receipt='{receipt_schema}'): {reason}"
-    )]
-    ReducerReceiptSchemaMismatch {
-        reducer_event_schema: String,
-        receipt_schema: String,
-        reason: String,
-    },
     #[error("capability grant '{0}' not found")]
     CapabilityGrantNotFound(String),
     #[error("capability definition '{0}' not found")]

--- a/crates/aos-kernel/src/error.rs
+++ b/crates/aos-kernel/src/error.rs
@@ -20,6 +20,14 @@ pub enum KernelError {
     ReceiptDecode(String),
     #[error("unsupported reducer receipt kind '{0}'")]
     UnsupportedReducerReceipt(String),
+    #[error(
+        "reducer receipt schema mismatch (event='{reducer_event_schema}', receipt='{receipt_schema}'): {reason}"
+    )]
+    ReducerReceiptSchemaMismatch {
+        reducer_event_schema: String,
+        receipt_schema: String,
+        reason: String,
+    },
     #[error("capability grant '{0}' not found")]
     CapabilityGrantNotFound(String),
     #[error("capability definition '{0}' not found")]

--- a/crates/aos-kernel/src/receipts.rs
+++ b/crates/aos-kernel/src/receipts.rs
@@ -1,4 +1,3 @@
-use aos_air_types::{HashRef, TypeExpr};
 use aos_cbor::Hash;
 use aos_effects::builtins::{
     BlobGetParams, BlobGetReceipt, BlobPutParams, BlobPutReceipt, TimerSetParams, TimerSetReceipt,
@@ -64,19 +63,11 @@ struct BlobReceiptEvent<TParams, TReceipt> {
 pub fn build_reducer_receipt_event(
     ctx: &ReducerEffectContext,
     receipt: &EffectReceipt,
-    reducer_event_schema: &str,
-    reducer_event_type: &TypeExpr,
 ) -> Result<DomainEvent, KernelError> {
     match ctx.effect_kind.as_str() {
-        aos_effects::EffectKind::TIMER_SET => {
-            build_timer_event(ctx, receipt, reducer_event_schema, reducer_event_type)
-        }
-        aos_effects::EffectKind::BLOB_PUT => {
-            build_blob_put_event(ctx, receipt, reducer_event_schema, reducer_event_type)
-        }
-        aos_effects::EffectKind::BLOB_GET => {
-            build_blob_get_event(ctx, receipt, reducer_event_schema, reducer_event_type)
-        }
+        aos_effects::EffectKind::TIMER_SET => build_timer_event(ctx, receipt),
+        aos_effects::EffectKind::BLOB_PUT => build_blob_put_event(ctx, receipt),
+        aos_effects::EffectKind::BLOB_GET => build_blob_get_event(ctx, receipt),
         other => Err(KernelError::UnsupportedReducerReceipt(other.to_string())),
     }
 }
@@ -84,8 +75,6 @@ pub fn build_reducer_receipt_event(
 fn build_timer_event(
     ctx: &ReducerEffectContext,
     receipt: &EffectReceipt,
-    reducer_event_schema: &str,
-    reducer_event_type: &TypeExpr,
 ) -> Result<DomainEvent, KernelError> {
     let requested: TimerSetParams = decode(&ctx.params_cbor)?;
     let timer_receipt: TimerSetReceipt = decode(&receipt.payload_cbor)?;
@@ -100,19 +89,12 @@ fn build_timer_event(
         cost_cents: receipt.cost_cents,
         signature: receipt.signature.clone(),
     };
-    encode_event(
-        SYS_TIMER_FIRED_SCHEMA,
-        payload,
-        reducer_event_schema,
-        reducer_event_type,
-    )
+    encode_event(SYS_TIMER_FIRED_SCHEMA, payload)
 }
 
 fn build_blob_put_event(
     ctx: &ReducerEffectContext,
     receipt: &EffectReceipt,
-    reducer_event_schema: &str,
-    reducer_event_type: &TypeExpr,
 ) -> Result<DomainEvent, KernelError> {
     let requested: BlobPutParams = decode(&ctx.params_cbor)?;
     let blob_receipt: BlobPutReceipt = decode(&receipt.payload_cbor)?;
@@ -127,19 +109,12 @@ fn build_blob_put_event(
         cost_cents: receipt.cost_cents,
         signature: receipt.signature.clone(),
     };
-    encode_event(
-        SYS_BLOB_PUT_RESULT_SCHEMA,
-        payload,
-        reducer_event_schema,
-        reducer_event_type,
-    )
+    encode_event(SYS_BLOB_PUT_RESULT_SCHEMA, payload)
 }
 
 fn build_blob_get_event(
     ctx: &ReducerEffectContext,
     receipt: &EffectReceipt,
-    reducer_event_schema: &str,
-    reducer_event_type: &TypeExpr,
 ) -> Result<DomainEvent, KernelError> {
     let requested: BlobGetParams = decode(&ctx.params_cbor)?;
     let blob_receipt: BlobGetReceipt = decode(&receipt.payload_cbor)?;
@@ -154,79 +129,16 @@ fn build_blob_get_event(
         cost_cents: receipt.cost_cents,
         signature: receipt.signature.clone(),
     };
-    encode_event(
-        SYS_BLOB_GET_RESULT_SCHEMA,
-        payload,
-        reducer_event_schema,
-        reducer_event_type,
-    )
+    encode_event(SYS_BLOB_GET_RESULT_SCHEMA, payload)
 }
 
 fn encode_event<T: Serialize>(
     receipt_schema: &str,
     payload: T,
-    reducer_event_schema: &str,
-    reducer_event_type: &TypeExpr,
 ) -> Result<DomainEvent, KernelError> {
-    let value = serde_cbor::to_value(&payload)
-        .map_err(|err| KernelError::ReceiptDecode(err.to_string()))?;
-    let bytes = wrap_payload_for_reducer_event(
-        reducer_event_schema,
-        reducer_event_type,
-        receipt_schema,
-        value,
-    )?;
-    Ok(DomainEvent::new(reducer_event_schema, bytes))
-}
-
-fn wrap_payload_for_reducer_event(
-    reducer_event_schema: &str,
-    reducer_event_type: &TypeExpr,
-    receipt_schema: &str,
-    payload: serde_cbor::Value,
-) -> Result<Vec<u8>, KernelError> {
-    if reducer_event_schema == receipt_schema {
-        return serde_cbor::to_vec(&payload)
-            .map_err(|err| KernelError::ReceiptDecode(err.to_string()));
-    }
-    let TypeExpr::Variant(variant) = reducer_event_type else {
-        return Err(KernelError::ReducerReceiptSchemaMismatch {
-            reducer_event_schema: reducer_event_schema.to_string(),
-            receipt_schema: receipt_schema.to_string(),
-            reason: "reducer event schema is not a variant".into(),
-        });
-    };
-    let mut tag = None;
-    for (name, ty) in &variant.variant {
-        if let TypeExpr::Ref(reference) = ty {
-            if reference.reference.as_str() == receipt_schema {
-                if tag.is_some() {
-                    return Err(KernelError::ReducerReceiptSchemaMismatch {
-                        reducer_event_schema: reducer_event_schema.to_string(),
-                        receipt_schema: receipt_schema.to_string(),
-                        reason: "receipt schema appears in multiple variant arms".into(),
-                    });
-                }
-                tag = Some(name.clone());
-            }
-        }
-    }
-    let tag = tag.ok_or_else(|| KernelError::ReducerReceiptSchemaMismatch {
-        reducer_event_schema: reducer_event_schema.to_string(),
-        receipt_schema: receipt_schema.to_string(),
-        reason: "receipt schema not found in variant".into(),
-    })?;
-    let wrapped = serde_cbor::Value::Map(vec![
-        (
-            serde_cbor::Value::Text("$tag".into()),
-            serde_cbor::Value::Text(tag),
-        ),
-        (
-            serde_cbor::Value::Text("$value".into()),
-            payload,
-        ),
-    ]);
-    serde_cbor::to_vec(&wrapped).map_err(|err| KernelError::ReceiptDecode(err.to_string()))
+    let bytes =
+        serde_cbor::to_vec(&payload).map_err(|err| KernelError::ReceiptDecode(err.to_string()))?;
+    Ok(DomainEvent::new(receipt_schema, bytes))
 }
 
 fn hash_to_hex(bytes: &[u8; 32]) -> String {
@@ -242,9 +154,8 @@ fn decode<T: serde::de::DeserializeOwned>(bytes: &[u8]) -> Result<T, KernelError
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aos_air_types::HashRef;
     use aos_effects::EffectReceipt;
-    use aos_air_types::{SchemaRef, TypeRef, TypeVariant};
-    use indexmap::IndexMap;
     use serde::Deserialize;
 
     fn fake_hash(byte: u8) -> HashRef {
@@ -263,32 +174,16 @@ mod tests {
         }
     }
 
-    fn reducer_event_variant(schema: &str, tag: &str) -> (String, TypeExpr) {
-        let mut variants = IndexMap::new();
-        variants.insert(
-            tag.to_string(),
-            TypeExpr::Ref(TypeRef {
-                reference: SchemaRef::new(schema).unwrap(),
-            }),
-        );
-        (
-            "com.acme/ReducerEvent@1".to_string(),
-            TypeExpr::Variant(TypeVariant { variant: variants }),
-        )
-    }
-
     /// Rejects reducer receipts whose effect kind is not part of the built-in micro-effect set.
     #[test]
     fn rejects_unknown_effect_kind() {
         let ctx = ReducerEffectContext::new("reducer".into(), "unknown".into(), vec![]);
         let receipt = base_receipt();
-        let (schema_name, schema_ty) = reducer_event_variant(SYS_TIMER_FIRED_SCHEMA, "Fired");
-        let err =
-            build_reducer_receipt_event(&ctx, &receipt, &schema_name, &schema_ty).unwrap_err();
+        let err = build_reducer_receipt_event(&ctx, &receipt).unwrap_err();
         assert!(matches!(err, KernelError::UnsupportedReducerReceipt(_)));
     }
 
-    /// Verifies timer receipts are wrapped into the reducer's variant schema.
+    /// Verifies timer receipts are encoded as sys/TimerFired@1 events.
     #[test]
     fn timer_receipt_event_is_structured() {
         let params = TimerSetParams {
@@ -307,10 +202,8 @@ mod tests {
         let mut receipt = base_receipt();
         receipt.payload_cbor = serde_cbor::to_vec(&timer_receipt).unwrap();
 
-        let (schema_name, schema_ty) = reducer_event_variant(SYS_TIMER_FIRED_SCHEMA, "Fired");
-        let event =
-            build_reducer_receipt_event(&ctx, &receipt, &schema_name, &schema_ty).expect("event");
-        assert_eq!(event.schema, schema_name);
+        let event = build_reducer_receipt_event(&ctx, &receipt).expect("event");
+        assert_eq!(event.schema, SYS_TIMER_FIRED_SCHEMA);
 
         #[derive(Deserialize)]
         struct EventPayload {
@@ -326,22 +219,7 @@ mod tests {
             signature: Vec<u8>,
         }
 
-        let value: serde_cbor::Value = serde_cbor::from_slice(&event.value).unwrap();
-        let serde_cbor::Value::Map(map) = value else {
-            panic!("expected variant map");
-        };
-        let mut tag = None;
-        let mut payload = None;
-        for (key, val) in map {
-            if key == serde_cbor::Value::Text("$tag".into()) {
-                tag = Some(val);
-            } else if key == serde_cbor::Value::Text("$value".into()) {
-                payload = Some(val);
-            }
-        }
-        assert_eq!(tag, Some(serde_cbor::Value::Text("Fired".into())));
-        let payload = payload.expect("payload");
-        let decoded: EventPayload = serde_cbor::value::from_value(payload).unwrap();
+        let decoded: EventPayload = serde_cbor::from_slice(&event.value).unwrap();
         assert_eq!(
             decoded.intent_hash,
             Hash::from_bytes(&receipt.intent_hash).unwrap().to_hex()
@@ -375,10 +253,8 @@ mod tests {
         let mut receipt = base_receipt();
         receipt.payload_cbor = serde_cbor::to_vec(&receipt_body).unwrap();
 
-        let (schema_name, schema_ty) = reducer_event_variant(SYS_BLOB_PUT_RESULT_SCHEMA, "Put");
-        let event =
-            build_reducer_receipt_event(&ctx, &receipt, &schema_name, &schema_ty).expect("event");
-        assert_eq!(event.schema, schema_name);
+        let event = build_reducer_receipt_event(&ctx, &receipt).expect("event");
+        assert_eq!(event.schema, SYS_BLOB_PUT_RESULT_SCHEMA);
 
         #[derive(Deserialize)]
         struct Payload {
@@ -386,17 +262,7 @@ mod tests {
             receipt: BlobPutReceipt,
         }
 
-        let value: serde_cbor::Value = serde_cbor::from_slice(&event.value).unwrap();
-        let serde_cbor::Value::Map(map) = value else {
-            panic!("expected variant map");
-        };
-        let payload = map
-            .into_iter()
-            .find_map(|(key, val)| {
-                (key == serde_cbor::Value::Text("$value".into())).then_some(val)
-            })
-            .expect("payload");
-        let decoded: Payload = serde_cbor::value::from_value(payload).unwrap();
+        let decoded: Payload = serde_cbor::from_slice(&event.value).unwrap();
         assert_eq!(decoded.requested.namespace, "ns");
         assert_eq!(decoded.receipt.size, 42);
     }
@@ -419,10 +285,8 @@ mod tests {
         let mut receipt = base_receipt();
         receipt.payload_cbor = serde_cbor::to_vec(&receipt_body).unwrap();
 
-        let (schema_name, schema_ty) = reducer_event_variant(SYS_BLOB_GET_RESULT_SCHEMA, "Get");
-        let event =
-            build_reducer_receipt_event(&ctx, &receipt, &schema_name, &schema_ty).expect("event");
-        assert_eq!(event.schema, schema_name);
+        let event = build_reducer_receipt_event(&ctx, &receipt).expect("event");
+        assert_eq!(event.schema, SYS_BLOB_GET_RESULT_SCHEMA);
 
         #[derive(Deserialize)]
         struct Payload {
@@ -430,17 +294,7 @@ mod tests {
             receipt: BlobGetReceipt,
         }
 
-        let value: serde_cbor::Value = serde_cbor::from_slice(&event.value).unwrap();
-        let serde_cbor::Value::Map(map) = value else {
-            panic!("expected variant map");
-        };
-        let payload = map
-            .into_iter()
-            .find_map(|(key, val)| {
-                (key == serde_cbor::Value::Text("$value".into())).then_some(val)
-            })
-            .expect("payload");
-        let decoded: Payload = serde_cbor::value::from_value(payload).unwrap();
+        let decoded: Payload = serde_cbor::from_slice(&event.value).unwrap();
         assert_eq!(decoded.requested.key, "doc");
         assert_eq!(decoded.receipt.blob_ref, receipt_body.blob_ref);
     }

--- a/crates/aos-kernel/src/world.rs
+++ b/crates/aos-kernel/src/world.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fmt;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -192,9 +192,18 @@ struct PlanTriggerBinding {
 }
 
 #[derive(Clone, Debug)]
+enum EventWrap {
+    Identity,
+    Variant { tag: String },
+}
+
+#[derive(Clone, Debug)]
 struct RouteBinding {
     reducer: Name,
     key_field: Option<String>,
+    route_event_schema: String,
+    reducer_event_schema: String,
+    wrap: EventWrap,
 }
 
 #[derive(Clone)]
@@ -417,18 +426,12 @@ impl<S: Store + 'static> Kernel<S> {
         config: KernelConfig,
     ) -> Result<Self, KernelError> {
         let secret_resolver = select_secret_resolver(!loaded.secrets.is_empty(), &config)?;
-        let mut router = HashMap::new();
-        if let Some(routing) = loaded.manifest.routing.as_ref() {
-            for route in &routing.events {
-                router
-                    .entry(route.event.as_str().to_string())
-                    .or_insert_with(Vec::new)
-                    .push(RouteBinding {
-                        reducer: route.reducer.clone(),
-                        key_field: route.key_field.clone(),
-                    });
-            }
-        }
+        let schema_index = Arc::new(build_schema_index_from_loaded(store.as_ref(), &loaded)?);
+        let reducer_schemas = Arc::new(build_reducer_schemas(
+            &loaded.modules,
+            schema_index.as_ref(),
+        )?);
+        let router = build_router(&loaded.manifest, reducer_schemas.as_ref())?;
         let mut plan_registry = PlanRegistry::default();
         for plan in loaded.plans.values() {
             plan_registry.register(plan.clone());
@@ -446,7 +449,6 @@ impl<S: Store + 'static> Kernel<S> {
         for bindings in plan_triggers.values_mut() {
             bindings.sort_by(|a, b| a.plan.cmp(&b.plan));
         }
-        let schema_index = Arc::new(build_schema_index_from_loaded(store.as_ref(), &loaded)?);
         let effect_catalog = Arc::new(loaded.effect_catalog.clone());
         let capability_resolver = CapabilityResolver::from_manifest(
             &loaded.manifest,
@@ -456,10 +458,6 @@ impl<S: Store + 'static> Kernel<S> {
         )?;
         ensure_plan_capabilities(&loaded.plans, &capability_resolver)?;
         ensure_module_capabilities(&loaded.manifest, &capability_resolver)?;
-        let reducer_schemas = Arc::new(build_reducer_schemas(
-            &loaded.modules,
-            schema_index.as_ref(),
-        )?);
         let policy_gate: Box<dyn crate::policy::PolicyGate> = match loaded
             .manifest
             .defaults
@@ -635,6 +633,13 @@ impl<S: Store + 'static> Kernel<S> {
                 .module_defs
                 .get(&binding.reducer)
                 .ok_or_else(|| KernelError::ReducerNotFound(binding.reducer.clone()))?;
+            let reducer_schema =
+                self.reducer_schemas.get(&binding.reducer).ok_or_else(|| {
+                    KernelError::Manifest(format!(
+                        "schema for reducer '{}' not found while routing event",
+                        binding.reducer
+                    ))
+                })?;
             let keyed = module_def.key_schema.is_some();
 
             match (keyed, &binding.key_field) {
@@ -653,6 +658,25 @@ impl<S: Store + 'static> Kernel<S> {
                 _ => {}
             }
 
+            let wrapped_value = match &binding.wrap {
+                EventWrap::Identity => event_value.clone(),
+                EventWrap::Variant { tag } => CborValue::Map(BTreeMap::from([
+                    (
+                        CborValue::Text("$tag".into()),
+                        CborValue::Text(tag.clone()),
+                    ),
+                    (CborValue::Text("$value".into()), event_value.clone()),
+                ])),
+            };
+            let normalized_for_reducer =
+                normalize_value_with_schema(wrapped_value, &reducer_schema.event_schema, &self.schema_index)
+                    .map_err(|err| {
+                        KernelError::Manifest(format!(
+                            "failed to encode event '{}' for reducer '{}': {err}",
+                            event.schema, binding.reducer
+                        ))
+                    })?;
+
             let key_bytes = if let Some(field) = &binding.key_field {
                 let key_schema_ref = module_def
                     .key_schema
@@ -668,7 +692,17 @@ impl<S: Store + 'static> Kernel<S> {
                                 binding.reducer
                             ))
                         })?;
-                Some(self.extract_key_bytes(field, key_schema, &event_value, &event.schema)?)
+                let value_for_key = if binding.route_event_schema == event.schema {
+                    &event_value
+                } else {
+                    &normalized_for_reducer.value
+                };
+                Some(self.extract_key_bytes(
+                    field,
+                    key_schema,
+                    value_for_key,
+                    binding.route_event_schema.as_str(),
+                )?)
             } else {
                 None
             };
@@ -682,7 +716,11 @@ impl<S: Store + 'static> Kernel<S> {
                 }
             }
 
-            let mut routed_event = event.clone();
+            let mut routed_event = DomainEvent::new(
+                binding.reducer_event_schema.clone(),
+                normalized_for_reducer.bytes,
+            );
+            routed_event.key = event.key.clone();
             if let Some(bytes) = key_bytes.clone() {
                 routed_event.key = Some(bytes);
             }
@@ -1799,18 +1837,7 @@ impl<S: Store + 'static> Kernel<S> {
             self.plan_registry.register(plan.clone());
         }
 
-        self.router.clear();
-        if let Some(routing) = self.manifest.routing.as_ref() {
-            for route in &routing.events {
-                self.router
-                    .entry(route.event.as_str().to_string())
-                    .or_insert_with(Vec::new)
-                    .push(RouteBinding {
-                        reducer: route.reducer.clone(),
-                        key_field: route.key_field.clone(),
-                    });
-            }
-        }
+        self.router = build_router(&self.manifest, reducer_schemas.as_ref())?;
 
         let mut plan_triggers = HashMap::new();
         for trigger in &self.manifest.triggers {
@@ -2046,18 +2073,7 @@ impl<S: Store + 'static> Kernel<S> {
 
         if let Some(context) = self.pending_reducer_receipts.remove(&receipt.intent_hash) {
             self.record_effect_receipt(&receipt)?;
-            let reducer_schema = self.reducer_schemas.get(&context.reducer).ok_or_else(|| {
-                KernelError::Manifest(format!(
-                    "schema for reducer '{}' not found while handling receipt",
-                    context.reducer
-                ))
-            })?;
-            let event = build_reducer_receipt_event(
-                &context,
-                &receipt,
-                &reducer_schema.event_schema_name,
-                &reducer_schema.event_schema,
-            )?;
+            let event = build_reducer_receipt_event(&context, &receipt)?;
             self.process_domain_event(event)?;
             self.remember_receipt(receipt.intent_hash);
             return Ok(());
@@ -3295,6 +3311,145 @@ fn build_reducer_schemas(
         }
     }
     Ok(map)
+}
+
+fn build_router(
+    manifest: &Manifest,
+    reducer_schemas: &HashMap<Name, ReducerSchema>,
+) -> Result<HashMap<String, Vec<RouteBinding>>, KernelError> {
+    let mut router = HashMap::new();
+    let Some(routing) = manifest.routing.as_ref() else {
+        return Ok(router);
+    };
+
+    for route in &routing.events {
+        let reducer_schema =
+            reducer_schemas
+                .get(&route.reducer)
+                .ok_or_else(|| KernelError::Manifest(format!(
+                    "schema for reducer '{}' not found while building router",
+                    route.reducer
+                )))?;
+        let route_event = route.event.as_str();
+        let reducer_event_schema = reducer_schema.event_schema_name.as_str();
+        if route_event == reducer_event_schema {
+            push_route_binding(
+                &mut router,
+                route_event,
+                route_event,
+                reducer_schema,
+                route.key_field.clone(),
+                EventWrap::Identity,
+                &route.reducer,
+            );
+            match &reducer_schema.event_schema {
+                TypeExpr::Ref(reference) => {
+                    let member = reference.reference.as_str();
+                    push_route_binding(
+                        &mut router,
+                        member,
+                        route_event,
+                        reducer_schema,
+                        route.key_field.clone(),
+                        EventWrap::Identity,
+                        &route.reducer,
+                    );
+                }
+                TypeExpr::Variant(variant) => {
+                    for (tag, ty) in &variant.variant {
+                        if let TypeExpr::Ref(reference) = ty {
+                            push_route_binding(
+                                &mut router,
+                                reference.reference.as_str(),
+                                route_event,
+                                reducer_schema,
+                                route.key_field.clone(),
+                                EventWrap::Variant { tag: tag.clone() },
+                                &route.reducer,
+                            );
+                        }
+                    }
+                }
+                _ => {}
+            }
+        } else {
+            let wrap = wrap_for_event_schema(route_event, reducer_schema)?;
+            push_route_binding(
+                &mut router,
+                route_event,
+                route_event,
+                reducer_schema,
+                route.key_field.clone(),
+                wrap,
+                &route.reducer,
+            );
+        }
+    }
+
+    Ok(router)
+}
+
+fn push_route_binding(
+    router: &mut HashMap<String, Vec<RouteBinding>>,
+    event_key: &str,
+    route_event_schema: &str,
+    reducer_schema: &ReducerSchema,
+    key_field: Option<String>,
+    wrap: EventWrap,
+    reducer: &str,
+) {
+    router
+        .entry(event_key.to_string())
+        .or_insert_with(Vec::new)
+        .push(RouteBinding {
+            reducer: reducer.to_string(),
+            key_field,
+            route_event_schema: route_event_schema.to_string(),
+            reducer_event_schema: reducer_schema.event_schema_name.clone(),
+            wrap,
+        });
+}
+
+fn wrap_for_event_schema(
+    event_schema: &str,
+    reducer_schema: &ReducerSchema,
+) -> Result<EventWrap, KernelError> {
+    if event_schema == reducer_schema.event_schema_name {
+        return Ok(EventWrap::Identity);
+    }
+    match &reducer_schema.event_schema {
+        TypeExpr::Ref(reference) if reference.reference.as_str() == event_schema => {
+            Ok(EventWrap::Identity)
+        }
+        TypeExpr::Variant(variant) => {
+            let mut found = None;
+            for (tag, ty) in &variant.variant {
+                if let TypeExpr::Ref(reference) = ty {
+                    if reference.reference.as_str() == event_schema {
+                        if found.is_some() {
+                            return Err(KernelError::Manifest(format!(
+                                "event '{event_schema}' appears in multiple variant arms for reducer schema '{}'",
+                                reducer_schema.event_schema_name
+                            )));
+                        }
+                        found = Some(tag.clone());
+                    }
+                }
+            }
+            found
+                .map(|tag| EventWrap::Variant { tag })
+                .ok_or_else(|| {
+                    KernelError::Manifest(format!(
+                        "event '{event_schema}' is not in reducer schema '{}' family",
+                        reducer_schema.event_schema_name
+                    ))
+                })
+        }
+        _ => Err(KernelError::Manifest(format!(
+            "event '{event_schema}' is not in reducer schema '{}' family",
+            reducer_schema.event_schema_name
+        ))),
+    }
 }
 
 fn ensure_plan_capabilities(

--- a/crates/aos-store/src/manifest.rs
+++ b/crates/aos-store/src/manifest.rs
@@ -188,15 +188,11 @@ fn normalize_plan_literals(nodes: &mut HashMap<String, CatalogEntry>) -> StoreRe
     use aos_air_types::plan_literals::normalize_plan_literals;
 
     let mut schema_map = HashMap::new();
-    let mut module_map = HashMap::new();
     let mut effect_defs = Vec::new();
     for entry in nodes.values() {
         match &entry.node {
             AirNode::Defschema(schema) => {
                 schema_map.insert(schema.name.clone(), schema.ty.clone());
-            }
-            AirNode::Defmodule(module) => {
-                module_map.insert(module.name.clone(), module.clone());
             }
             AirNode::Defeffect(effect) => effect_defs.push(effect.clone()),
             _ => {}
@@ -211,7 +207,7 @@ fn normalize_plan_literals(nodes: &mut HashMap<String, CatalogEntry>) -> StoreRe
     let effect_catalog = aos_air_types::catalog::EffectCatalog::from_defs(effect_defs);
     for (name, entry) in nodes.iter_mut() {
         if let AirNode::Defplan(plan) = &mut entry.node {
-            normalize_plan_literals(plan, &schema_index, &module_map, &effect_catalog).map_err(
+            normalize_plan_literals(plan, &schema_index, &effect_catalog).map_err(
                 |source| StoreError::PlanNormalization {
                     name: name.clone(),
                     source,
@@ -470,7 +466,7 @@ fn validate_plan_secrets(
     for step in &plan.steps {
         match &step.kind {
             PlanStepKind::RaiseEvent(step) => {
-                collect_secret_refs_in_expr_or_value(&step.event, &mut refs);
+                collect_secret_refs_in_expr_or_value(&step.value, &mut refs);
             }
             PlanStepKind::EmitEffect(step) => {
                 collect_secret_refs_in_expr_or_value(&step.params, &mut refs);

--- a/examples/01-hello-timer/README.md
+++ b/examples/01-hello-timer/README.md
@@ -1,4 +1,4 @@
 # Example 01 — Hello Timer
 
-- Scope: reducer emits `timer.set`, handles `sys/TimerFired@1` receipts.
+- Scope: reducer emits `timer.set`, handles `TimerEvent::Fired` (wrapped `sys/TimerFired@1` receipt).
 - Follow the detailed spec in TODO.MD when populating `air/` and the reducer crate.

--- a/examples/01-hello-timer/air/manifest.air.json
+++ b/examples/01-hello-timer/air/manifest.air.json
@@ -60,10 +60,6 @@
       {
         "event": "demo/TimerEvent@1",
         "reducer": "demo/TimerSM@1"
-      },
-      {
-        "event": "sys/TimerFired@1",
-        "reducer": "demo/TimerSM@1"
       }
     ],
     "inboxes": []

--- a/examples/02-blob-echo/air/manifest.air.json
+++ b/examples/02-blob-echo/air/manifest.air.json
@@ -69,14 +69,6 @@
       {
         "event": "demo/BlobEchoEvent@1",
         "reducer": "demo/BlobEchoSM@1"
-      },
-      {
-        "event": "sys/BlobPutResult@1",
-        "reducer": "demo/BlobEchoSM@1"
-      },
-      {
-        "event": "sys/BlobGetResult@1",
-        "reducer": "demo/BlobEchoSM@1"
       }
     ],
     "inboxes": []

--- a/examples/02-blob-echo/air/schemas.air.json
+++ b/examples/02-blob-echo/air/schemas.air.json
@@ -35,7 +35,9 @@
             "key": { "text": {} },
             "data": { "bytes": {} }
           }
-        }
+        },
+        "PutResult": { "ref": "sys/BlobPutResult@1" },
+        "GetResult": { "ref": "sys/BlobGetResult@1" }
       }
     }
   }

--- a/examples/03-fetch-notify/air/fetch_plan.air.json
+++ b/examples/03-fetch-notify/air/fetch_plan.air.json
@@ -50,8 +50,8 @@
       {
         "id": "raise_result",
         "op": "raise_event",
-        "reducer": "demo/FetchNotify@1",
-        "event": {
+        "event": "demo/FetchNotifyEvent@1",
+        "value": {
           "variant": {
             "tag": "NotifyComplete",
             "value": {

--- a/examples/04-aggregator/air/aggregator_plan.air.json
+++ b/examples/04-aggregator/air/aggregator_plan.air.json
@@ -262,8 +262,8 @@
       {
         "id": "raise_result",
         "op": "raise_event",
-        "reducer": "demo/Aggregator@1",
-        "event": {
+        "event": "demo/AggregatorEvent@1",
+        "value": {
           "variant": {
             "tag": "AggregateComplete",
             "value": {

--- a/examples/05-chain-comp/air/charge_plan.air.json
+++ b/examples/05-chain-comp/air/charge_plan.air.json
@@ -40,8 +40,8 @@
       {
         "id": "raise_result",
         "op": "raise_event",
-        "reducer": "demo/ChainComp@1",
-        "event": {
+        "event": "demo/ChainEvent@1",
+        "value": {
           "variant": {
             "tag": "ChargeCompleted",
             "value": {

--- a/examples/05-chain-comp/air/notify_plan.air.json
+++ b/examples/05-chain-comp/air/notify_plan.air.json
@@ -40,8 +40,8 @@
       {
         "id": "raise_result",
         "op": "raise_event",
-        "reducer": "demo/ChainComp@1",
-        "event": {
+        "event": "demo/ChainEvent@1",
+        "value": {
           "variant": {
             "tag": "NotifyCompleted",
             "value": {

--- a/examples/05-chain-comp/air/refund_plan.air.json
+++ b/examples/05-chain-comp/air/refund_plan.air.json
@@ -40,8 +40,8 @@
       {
         "id": "raise_result",
         "op": "raise_event",
-        "reducer": "demo/ChainComp@1",
-        "event": {
+        "event": "demo/ChainEvent@1",
+        "value": {
           "variant": {
             "tag": "RefundCompleted",
             "value": {

--- a/examples/05-chain-comp/air/reserve_plan.air.json
+++ b/examples/05-chain-comp/air/reserve_plan.air.json
@@ -52,8 +52,8 @@
       {
         "id": "raise_success",
         "op": "raise_event",
-        "reducer": "demo/ChainComp@1",
-        "event": {
+        "event": "demo/ChainEvent@1",
+        "value": {
           "variant": {
             "tag": "ReserveCompleted",
             "value": {
@@ -81,8 +81,8 @@
       {
         "id": "raise_failure",
         "op": "raise_event",
-        "reducer": "demo/ChainComp@1",
-        "event": {
+        "event": "demo/ChainEvent@1",
+        "value": {
           "variant": {
             "tag": "ReserveFailed",
             "value": {

--- a/examples/06-safe-upgrade/air.v1/fetch_plan.air.json
+++ b/examples/06-safe-upgrade/air.v1/fetch_plan.air.json
@@ -33,8 +33,8 @@
       {
         "id": "raise_complete",
         "op": "raise_event",
-        "reducer": "demo/SafeUpgrade@1",
-        "event": {
+        "event": "demo/SafeUpgradeEvent@1",
+        "value": {
           "variant": {
             "tag": "NotifyComplete",
             "value": {

--- a/examples/06-safe-upgrade/air.v2/fetch_plan_v2.air.json
+++ b/examples/06-safe-upgrade/air.v2/fetch_plan_v2.air.json
@@ -73,8 +73,8 @@
       {
         "id": "raise_complete",
         "op": "raise_event",
-        "reducer": "demo/SafeUpgrade@1",
-        "event": {
+        "event": "demo/SafeUpgradeEvent@1",
+        "value": {
           "variant": {
             "tag": "NotifyComplete",
             "value": {

--- a/examples/07-llm-summarizer/air/summarize_plan.air.json
+++ b/examples/07-llm-summarizer/air/summarize_plan.air.json
@@ -122,8 +122,8 @@
       {
         "id": "raise_result",
         "op": "raise_event",
-        "reducer": "demo/LlmSummarizer@1",
-        "event": {
+        "event": "demo/LlmSummarizerEvent@1",
+        "value": {
           "variant": {
             "tag": "SummaryReady",
             "value": {

--- a/examples/08-retry-backoff/air/manifest.air.json
+++ b/examples/08-retry-backoff/air/manifest.air.json
@@ -86,19 +86,7 @@
   "routing": {
     "events": [
       {
-        "event": "demo/StartWork@1",
-        "reducer": "demo/RetrySM@1"
-      },
-      {
-        "event": "demo/WorkOk@1",
-        "reducer": "demo/RetrySM@1"
-      },
-      {
-        "event": "demo/WorkErr@1",
-        "reducer": "demo/RetrySM@1"
-      },
-      {
-        "event": "sys/TimerFired@1",
+        "event": "demo/RetryEvent@1",
         "reducer": "demo/RetrySM@1"
       }
     ],

--- a/examples/08-retry-backoff/air/plans.air.json
+++ b/examples/08-retry-backoff/air/plans.air.json
@@ -7,8 +7,8 @@
       {
         "id": "fail",
         "op": "raise_event",
-        "reducer": "demo/RetrySM@1",
-        "event": {
+        "event": "demo/RetryEvent@1",
+        "value": {
           "err": {
             "req_id": "req-123",
             "transient": true,

--- a/examples/09-worldfs-lab/README.md
+++ b/examples/09-worldfs-lab/README.md
@@ -4,6 +4,7 @@ A keyed notebook reducer plus ObjectCatalog and a small plan. Finalized notes tr
 
 ## What it does
 - Keyed reducer `notes/NotebookSM@1` owns one note per key.
+- Runner sends `notes/NoteEvent@1` variants (Start/Append/Finalize) to seed notes.
 - `NoteFinalized` emits `SnapshotRequested`; plan `notes/SnapshotPlan@1` does:
   1. `blob.put` the report (namespace = note_id).
   2. Raise `sys/ObjectRegistered@1` (object `notes/<id>/report`, kind `note.report`, tags `report,worldfs`).

--- a/examples/09-worldfs-lab/air/manifest.air.json
+++ b/examples/09-worldfs-lab/air/manifest.air.json
@@ -51,10 +51,7 @@
   },
   "routing": {
     "events": [
-      { "event": "notes/NoteStarted@1", "reducer": "notes/NotebookSM@1", "key_field": "note_id" },
-      { "event": "notes/NoteAppended@1", "reducer": "notes/NotebookSM@1", "key_field": "note_id" },
-      { "event": "notes/NoteFinalized@1", "reducer": "notes/NotebookSM@1", "key_field": "note_id" },
-      { "event": "notes/NoteArchived@1", "reducer": "notes/NotebookSM@1", "key_field": "note_id" },
+      { "event": "notes/NoteEvent@1", "reducer": "notes/NotebookSM@1", "key_field": "$value.note_id" },
       { "event": "sys/ObjectRegistered@1", "reducer": "sys/ObjectCatalog@1", "key_field": "meta.name" }
     ],
     "inboxes": []

--- a/examples/09-worldfs-lab/air/plans.air.json
+++ b/examples/09-worldfs-lab/air/plans.air.json
@@ -26,9 +26,8 @@
       {
         "id": "register_obj",
         "op": "raise_event",
-        "reducer": "sys/ObjectCatalog@1",
-        "key": { "ref": "@plan.input.object_path" },
-        "event": {
+        "event": "sys/ObjectRegistered@1",
+        "value": {
           "record": {
             "meta": {
               "record": {
@@ -46,9 +45,8 @@
       {
         "id": "archive_note",
         "op": "raise_event",
-        "reducer": "notes/NotebookSM@1",
-        "key": { "ref": "@plan.input.note_id" },
-        "event": {
+        "event": "notes/NoteEvent@1",
+        "value": {
           "variant": {
             "tag": "Archived",
             "value": {

--- a/roadmap/v0.4-query/p1-cells.md
+++ b/roadmap/v0.4-query/p1-cells.md
@@ -44,8 +44,8 @@ ReducerEffect shape: `{ kind: EffectKind, params: bytes (CBOR), cap_slot?: text 
 - manifest.routing.events: entries targeting a keyed reducer include a `key_field` telling the kernel where to find the key in the event value.
   - Non‑keyed: `{ event: SchemaRef, reducer: Name }`
   - Keyed: `{ event: SchemaRef, reducer: Name, key_field: "key" }`
-- defplan StepRaiseEvent adds a `key: Expr` for keyed reducers:
-  - `{ id, op: "raise_event", reducer: Name, key: Expr, event: Expr }`
+- defplan StepRaiseEvent publishes bus events with an explicit schema:
+  - `{ id, op: "raise_event", event: SchemaRef, value: ExprOrValue }`
 - manifest.triggers (already present): a trigger can specify `correlate_by` (e.g., `"key"`) so runs inherit an id they can use for await_event filters and observability.
 
 Note: v1 can already carry a `key` field in event values without kernel‑managed cells; v1.1 makes the key first‑class for routing/storage.
@@ -92,7 +92,7 @@ Note: v1 can already carry a `key` field in event values without kernel‑manage
 ## Status & TODO
 
 Done (in codebase)
-- Keyed routing/ABI: manifests use `key_field`; plans support `raise_event.key`; triggers can `correlate_by`.
+- Keyed routing/ABI: manifests use `key_field`; plans publish typed `raise_event` payloads; triggers can `correlate_by`.
 - Reducer calls carry `cell_mode` and key; `state=null` deletes the cell.
 - CAS-backed `CellIndex` per keyed reducer, with only the root hash stored in kernel state/snapshots; keyed load/save/delete go through the index.
 - Snapshots capture index roots; replay restores them. Legacy snapshots rebuild an empty index on load.
@@ -141,7 +141,7 @@ Deferred
 - Trigger with correlation:
   - `{ "event": "com.acme/ChargeRequested@1", "plan": "com.acme/charge_flow@3", "correlate_by": "key" }`
 - Plan step targeting a cell:
-  - `{ "id":"apply", "op":"raise_event", "reducer":"com.acme/OrderSM@2", "key": { "ref":"@plan.input.key" }, "event": { "record": { "order_id": { "ref":"@plan.input.order_id" } } } }`
+  - `{ "id":"apply", "op":"raise_event", "event":"com.acme/OrderEvent@2", "value": { "record": { "key": { "ref":"@plan.input.key" }, "order_id": { "ref":"@plan.input.order_id" } } } }`
 
 ## Non‑Goals (v1.1)
 

--- a/roadmap/v0.4-query/p3-normalize-effects.md
+++ b/roadmap/v0.4-query/p3-normalize-effects.md
@@ -10,7 +10,7 @@ Very important: the system is in very early development phase. So we can make th
 
 - Added a shared value normalizer (`crates/aos-air-types/src/value_normalize.rs`) and wired kernel ingestion to canonicalize every `DomainEvent` by its schema before routing/journaling; events are stored/replayed as canonical CBOR.
 - Routing/await now uses schema-aware decoding: keyed routes pull `key_field` via the declared key schema, plan `await_event` decodes by schema, and plan triggers build correlation from typed values.
-- Plan `raise_event` keys are emitted as canonical CBOR; reducer-emitted/bad payloads are rejected early; tests updated/added around routing, await_event, and invalid payload rejection.
+- Plan `raise_event` values are canonicalized against the explicit event schema; invalid payloads are rejected early; tests updated/added around routing, await_event, and invalid payload rejection.
 - External ingress now flows through the same normalizer: host/CLI/test helpers require an explicit schema string and kernel ingestion canonicalizes; adapter receipts that become events likewise pass through schema-based normalization before routing/journaling.
 - Open: docs/spec updates to reflect the “events like effect params; journal stores canonical CBOR” invariant.
 

--- a/roadmap/v0.5-upgrade/p1-event-dispatch.md
+++ b/roadmap/v0.5-upgrade/p1-event-dispatch.md
@@ -124,7 +124,7 @@ This keeps both v1 and your v1.1 “cells” direction consistent.
 
 ---
 
-## Plan `raise_event`: I would refactor it now **[PENDING]**
+## Plan `raise_event`: I would refactor it now **[DONE]**
 
 Your current ambiguity comes from “plan raise_event payload schema is inferred from reducer ABI schema.” That only works if the reducer ABI event is one schema and not a family/variant.
 
@@ -138,7 +138,6 @@ To make event families first-class *without* making plans build variant envelope
 
 * `event` is the schema name (SchemaRef)
 * `value` is `ExprOrValue` typed against that schema
-* optional `key` can remain (useful for keyed reducers), but you can also rely on `key_field` extraction
 
 This aligns plan emission with reducer emission: reducers already emit `{schema, value}` for domain events. 
 And it aligns with the AIR plan philosophy that payload schemas are known from context and canonicalized before journaling. 
@@ -158,8 +157,7 @@ This cleanly separates “publish” from “deliver.”
 
 * Update `spec/schemas/defplan.schema.json` `StepRaiseEvent`:
 
-  * replace `{ reducer, event }` with `{ event, value }` (or `{ schema, event }`, naming bikeshed)
-  * keep `key?` if you want
+  * replace `{ reducer, event }` with `{ event, value }`
      
 
 * Update the AIR prose in `03-air.md` accordingly. 
@@ -274,7 +272,7 @@ For each target:
 * wrap `value_cbor(E)` into `value_cbor(F)` if needed
 * invoke reducer with ABI event bytes = canonical CBOR of F
 
-### 4) Plans: change `raise_event` to publish (schema, value) **[PENDING]**
+### 4) Plans: change `raise_event` to publish (schema, value) **[DONE]**
 
 In `plan.rs` (your mention), change `raise_event` so it canonicalizes `value` against the explicit `event` schema (not reducer ABI). This matches the AIR “event payload normalization” model. 
 
@@ -291,7 +289,7 @@ The effect catalog already defines which effects are reducer-origin scoped.
 
 ---
 
-## Spec/doc updates I would make **[PENDING]**
+## Spec/doc updates I would make **[DONE]**
 
 1. **03-air.md**: make the routing/ABI relationship explicit and normative (validator rule). 
 2. **04-reducers.md**: clarify that reducers receive their declared event family, and the kernel wraps bus events into that family. 

--- a/roadmap/v0.5-upgrade/p1-event-dispatch.md
+++ b/roadmap/v0.5-upgrade/p1-event-dispatch.md
@@ -1,0 +1,306 @@
+# Typed Bus + Event-Family Dispatch
+
+Here’s the design I would lock in. It keeps the system **fully typed end‑to‑end**, removes the current ambiguity/mismatch, and still gives you “bigger refactor” headroom without committing you to self‑describing payloads or schema‑aware reducers.
+
+---
+
+## Decision
+
+### Make routing *strictly type-checked* against the reducer’s declared event ABI, and have the kernel **wrap/convert** bus events into the reducer’s **event-family** schema at dispatch time.
+
+Concretely:
+
+* The journal/bus carries **DomainEvents** as: **(schema_name, canonical_value_bytes, optional_key)**. This matches the AIR “journal invariant” model: *events are canonicalized against the schema they claim* and the journal stores only canonical bytes. 
+* `manifest.routing.events` remains the **wiring table** (who gets what).  
+* `defmodule.abi.reducer.event` becomes what it always *wanted* to be: the reducer’s **event-family** schema (one schema), but typically a **variant of refs** to multiple event schemas (domain + receipt).  
+* The kernel **must** enforce at load/validation time that every routing entry is compatible with the reducer’s event family, and at runtime it **must never** deliver an event the reducer can’t decode according to its ABI.
+
+This resolves your “Purpose vs routing” tension by turning it into a clean two-layer model:
+
+* **ABI** answers: “What can this reducer decode?” (`defmodule.abi.reducer.event`)
+* **Routing** answers: “Which events are actually delivered?” (`manifest.routing.events`)
+
+…and the validator ensures they never disagree.
+
+---
+
+## Why this is the “perfect” shape
+
+### 1) It preserves the strongest invariant you want
+
+Reducers run in deterministic WASM and should deserialize events into an enum/struct reliably; they should not need dynamic dispatch on “schema name” at runtime. Your docs already set up that expectation: reducers consume canonical CBOR “matching the declared schema,” and `abi.reducer.event` is described as the “domain/receipt event type family.” 
+
+### 2) It eliminates today’s foot-gun
+
+Right now, routing can deliver *any schema* to *any reducer* if listed, and the reducer ABI doesn’t constrain dispatch. That’s exactly how you got the confirmed mismatches (routing `sys/BlobPutResult@1` to a reducer that declares `demo/BlobEchoEvent@1`, etc.). This design makes those worlds **fail fast at manifest validation**.
+
+### 3) It keeps event payloads non–self-describing
+
+You explicitly want to reject `$schema` embedded in payloads (“self-describing payloads are rejected”).  
+This design keeps schema identity where it belongs: **outside** the value bytes, in the event envelope and control plane.
+
+### 4) It supports “one schema per reducer” *and* multi-event inputs
+
+You don’t need to expand `defmodule.abi.reducer.event` to an array. You keep one schema per reducer, but that schema is a variant “family.” This is already consistent with the spec language around unions/variants for reducer input. 
+
+---
+
+## The key semantic change: dispatch performs a typed conversion
+
+### Bus event (journal) stays:
+
+```
+DomainEvent {
+  schema: E,
+  value_cbor: bytes(E),
+  key?: bytes(key_schema)   // optional
+}
+```
+
+(That’s the model described in AIR’s runtime/journal sections.) 
+
+### Reducer ABI still expects one schema F = `defmodule.abi.reducer.event`
+
+So the kernel converts:
+
+* If `F == E` (or `F` is a ref to `E`): deliver `value_cbor` directly.
+* If `F` is a `variant` family that contains a member that references `E`:
+
+  * wrap into `F` as `variant(tag_for_E, value)` and canonicalize as `F`
+  * deliver those bytes
+
+This is exactly the missing glue implied by calling `abi.reducer.event` a “type family,” while routing is per-schema.  
+
+---
+
+## Lock-in rules (these become validator rules)
+
+### Rule A — Routing compatibility (the big fix)
+
+For every `manifest.routing.events[] = { event: E, reducer: R, ... }`:
+
+1. Load reducer `R`’s ABI event schema `F = defmodule(R).abi.reducer.event`.  
+2. Require `E ∈ family(F)` where `family(F)` is:
+
+   * `{E}` if `F` is a ref to `E`, or
+   * `{E_i}` if `F` is a variant and each variant arm is a `ref` to some schema `E_i`
+3. If not, **manifest is invalid**.
+
+This alone prevents your current inconsistency class.
+
+### Rule B — Event-family schema shape (make it machine-checkable)
+
+To keep conversion deterministic and tooling-friendly, constrain event families:
+
+* `F` must be either:
+
+  * `ref: SomeSchema@v` (single-event reducer), **or**
+  * `variant: { Tag1: {ref:E1}, Tag2:{ref:E2}, ... }` (multi-event)
+* No two tags may reference the same `Ei` (avoid ambiguous mapping).
+
+This is a purely semantic validation on top of the JSON Schema shape system.  
+
+### Rule C — Keying must be coherent
+
+You already have `key_field` on routing entries for keyed reducers (cells) and mention kernel validation around key usage.  
+
+Make it strict:
+
+* If reducer `R` has `key_schema`, then:
+
+  * the routing entry **must** provide `key_field`
+  * and schema `E` **must** contain that field with type exactly equal to `R.key_schema`
+* At dispatch:
+
+  * if the DomainEvent envelope carries `key`, prefer it (after typecheck)
+  * else extract from `key_field`
+
+This keeps both v1 and your v1.1 “cells” direction consistent.  
+
+---
+
+## Plan `raise_event`: I would refactor it now
+
+Your current ambiguity comes from “plan raise_event payload schema is inferred from reducer ABI schema.” That only works if the reducer ABI event is one schema and not a family/variant.
+
+To make event families first-class *without* making plans build variant envelopes manually, I’d change the plan step to publish a **bus event** explicitly:
+
+### New `raise_event` shape (recommended)
+
+```json
+{ "id":"x", "op":"raise_event", "event": "com.acme/PaymentResult@1", "value": { ... } }
+```
+
+* `event` is the schema name (SchemaRef)
+* `value` is `ExprOrValue` typed against that schema
+* optional `key` can remain (useful for keyed reducers), but you can also rely on `key_field` extraction
+
+This aligns plan emission with reducer emission: reducers already emit `{schema, value}` for domain events. 
+And it aligns with the AIR plan philosophy that payload schemas are known from context and canonicalized before journaling. 
+
+### What I would remove
+
+I would remove `reducer: Name` from `raise_event`. It’s redundant with routing and causes hacks like “EventBus@1” in workflows just to get an event into the system. Your workflows doc literally shows that pattern. 
+
+With this change:
+
+* a plan can publish an event **even if no reducer is routed** (useful for plan-to-plan choreography via triggers / await_event)
+* reducers only see it if routing says so
+
+This cleanly separates “publish” from “deliver.”
+
+### Required spec + schema updates
+
+* Update `spec/schemas/defplan.schema.json` `StepRaiseEvent`:
+
+  * replace `{ reducer, event }` with `{ event, value }` (or `{ schema, event }`, naming bikeshed)
+  * keep `key?` if you want
+     
+
+* Update the AIR prose in `03-air.md` accordingly. 
+
+---
+
+## Micro-effect receipts: make them fit naturally
+
+Built-in receipt event schemas already exist (`sys/TimerFired@1`, `sys/BlobPutResult@1`, `sys/BlobGetResult@1`).  
+And built-in micro-effects are reducer-origin scoped (`blob.put/get`, `timer.set`). 
+
+Under this design:
+
+* These `sys/*` receipt schemas are just **ordinary bus event schemas**.
+* Reducers that emit micro-effects should include the corresponding `sys/*` receipt schemas in their event family variant (and the validator can enforce that if `effects_emitted` includes those micro-effect kinds).  
+
+I would also tweak the docs to stop implying you must manually route them; instead:
+
+* The kernel **always** appends the receipt-derived event (so replay is deterministic)
+* Delivery is via routing like any other event
+* Tooling should auto-suggest/auto-add routing entries for these `sys/*` schemas when a reducer declares a micro-effect kind (lint/fix)
+
+This avoids “micro-effects silently never resume the reducer because routing forgot a sys event.”
+
+---
+
+## How this fixes your flagged inconsistencies
+
+### Example: `sys/BlobPutResult@1` routed to `demo/BlobEchoSM@1` but ABI says `demo/BlobEchoEvent@1`
+
+With strict validation, the manifest would be rejected unless:
+
+* `demo/BlobEchoEvent@1` is a variant family including a member referencing `sys/BlobPutResult@1`, **or**
+* `demo/BlobEchoEvent@1` directly refs `sys/BlobPutResult@1` (unlikely)
+
+So you’d fix it by defining:
+
+```json
+{
+  "$kind": "defschema",
+  "name": "demo/BlobEchoEvent@1",
+  "type": {
+    "variant": {
+      "BlobPutResult": { "ref": "sys/BlobPutResult@1" },
+      "BlobGetResult": { "ref": "sys/BlobGetResult@1" },
+      "EchoRequested": { "ref": "demo/EchoRequested@1" }
+    }
+  }
+}
+```
+
+…and the kernel will wrap `sys/BlobPutResult@1` into `demo/BlobEchoEvent@1` before calling the reducer.
+
+### Example: wrapper schemas like `demo/TimerEvent@1` vs routing `sys/TimerFired@1`
+
+You no longer need “wrapper event schemas” purely for reducer ergonomics. If you want a friendly enum variant name, it’s *the event family tag*. The bus schema remains `sys/TimerFired@1`, routing stays `sys/TimerFired@1 → SomeReducer`, and the reducer sees `TimerFired(...)` inside its family variant.
+
+---
+
+## Exact code changes (by subsystem)
+
+I’ll describe this as a refactor plan you can implement in one pass.
+
+### 1) Loader/validator: build a compiled dispatch map
+
+When loading the manifest, compute:
+
+* `event_schema_map: SchemaName → SchemaHash/type`
+* `reducer_event_family: ReducerName → EventFamilyInfo`
+
+  * `EventFamilyInfo` includes `family_schema = F`
+  * and a mapping `member_event_schema E → wrapper_kind` where `wrapper_kind` is:
+
+    * `Identity` if `F == E`
+    * `Variant { tag }` if `F` is a variant and `tag` is the arm referencing `E`
+
+Then compile:
+
+* `dispatch_table: EventSchema E → [DispatchTarget]`
+
+  * each `DispatchTarget` includes:
+
+    * `reducer: R`
+    * `wrapper_kind` (Identity or Variant tag)
+    * `keying`: `{ unkeyed }` or `{ keyed: { key_schema, key_field } }`
+
+This is basically turning `manifest.routing.events` into an executable plan, but with full type info.
+
+### 2) Validation: enforce the lock-in rules
+
+In the validator (what you called `validate.rs`), add:
+
+* Routing entry compatibility check (Rule A)
+* Event family shape check (Rule B)
+* Key coherency check (Rule C)
+
+Fail the world load with a precise diagnostic:
+
+* which routing entry failed
+* expected family members vs actual
+* if `key_field` missing/mistyped
+
+This is the critical piece that makes misconfig impossible.
+
+### 3) Dispatch: wrap on delivery
+
+In `world.rs route_event` (your mention), use `dispatch_table[E]`:
+
+For each target:
+
+* compute `key` (if keyed; prefer envelope key else extract via key_field)
+* wrap `value_cbor(E)` into `value_cbor(F)` if needed
+* invoke reducer with ABI event bytes = canonical CBOR of F
+
+### 4) Plans: change `raise_event` to publish (schema, value)
+
+In `plan.rs` (your mention), change `raise_event` so it canonicalizes `value` against the explicit `event` schema (not reducer ABI). This matches the AIR “event payload normalization” model. 
+
+Then append a DomainEvent (schema, bytes, maybe key) and let routing deliver.
+
+### 5) Tooling/fixtures
+
+Anywhere that assumed “a reducer has exactly one event schema” should be updated to treat `defmodule.abi.reducer.event` as a family:
+
+* Ensure all family member schemas exist in `manifest.schemas`
+* If reducer declares micro-effects in `effects_emitted`, ensure the appropriate `sys/*` receipt schemas exist and (optionally) recommend routing entries
+
+The effect catalog already defines which effects are reducer-origin scoped. 
+
+---
+
+## Spec/doc updates I would make
+
+1. **03-air.md**: make the routing/ABI relationship explicit and normative (validator rule). 
+2. **04-reducers.md**: clarify that reducers receive their declared event family, and the kernel wraps bus events into that family. 
+3. **05-workflows.md**: remove “EventBus@1” workaround; show plan-to-plan choreography by publishing events and triggering on them. 
+4. Update **defplan.schema.json** to the new `raise_event` shape. 
+5. Optionally add a short “Event Families” subsection to the architecture doc under Router/Inbox. 
+
+---
+
+## What you get after this refactor
+
+* **No silent misroutes**: impossible to route an event schema to a reducer that can’t decode it.
+* **Reducers stay simple**: still one ABI event type; still deterministic decoding.
+* **Plans become clearer**: `raise_event` is symmetric with reducer-emitted events and supports plan→plan choreography without hacks.
+* **Routing is wiring, ABI is contract**: no conflation, no ambiguity.
+* **Cells stay compatible**: `key_field` remains meaningful and can be strictly validated.  
+

--- a/roadmap/v0.5-upgrade/p1-event-dispatch.md
+++ b/roadmap/v0.5-upgrade/p1-event-dispatch.md
@@ -46,7 +46,7 @@ You don’t need to expand `defmodule.abi.reducer.event` to an array. You keep o
 
 ---
 
-## The key semantic change: dispatch performs a typed conversion
+## The key semantic change: dispatch performs a typed conversion **[DONE]**
 
 ### Bus event (journal) stays:
 
@@ -76,7 +76,7 @@ This is exactly the missing glue implied by calling `abi.reducer.event` a “typ
 
 ## Lock-in rules (these become validator rules)
 
-### Rule A — Routing compatibility (the big fix)
+### Rule A — Routing compatibility (the big fix) **[DONE]**
 
 For every `manifest.routing.events[] = { event: E, reducer: R, ... }`:
 
@@ -93,7 +93,7 @@ Notes:
 
 This alone prevents your current inconsistency class.
 
-### Rule B — Event-family schema shape (make it machine-checkable)
+### Rule B — Event-family schema shape (make it machine-checkable) **[PENDING]**
 
 To keep conversion deterministic and tooling-friendly, constrain event families:
 
@@ -105,7 +105,7 @@ To keep conversion deterministic and tooling-friendly, constrain event families:
 
 This is a purely semantic validation on top of the JSON Schema shape system.  
 
-### Rule C — Keying must be coherent
+### Rule C — Keying must be coherent **[PENDING]**
 
 You already have `key_field` on routing entries for keyed reducers (cells) and mention kernel validation around key usage.  
 
@@ -124,7 +124,7 @@ This keeps both v1 and your v1.1 “cells” direction consistent.
 
 ---
 
-## Plan `raise_event`: I would refactor it now
+## Plan `raise_event`: I would refactor it now **[PENDING]**
 
 Your current ambiguity comes from “plan raise_event payload schema is inferred from reducer ABI schema.” That only works if the reducer ABI event is one schema and not a family/variant.
 
@@ -166,7 +166,7 @@ This cleanly separates “publish” from “deliver.”
 
 ---
 
-## Micro-effect receipts: make them fit naturally
+## Micro-effect receipts: make them fit naturally **[DONE]**
 
 Built-in receipt event schemas already exist (`sys/TimerFired@1`, `sys/BlobPutResult@1`, `sys/BlobGetResult@1`).  
 And built-in micro-effects are reducer-origin scoped (`blob.put/get`, `timer.set`). 
@@ -223,7 +223,7 @@ You no longer need “wrapper event schemas” purely for reducer ergonomics. If
 
 I’ll describe this as a refactor plan you can implement in one pass.
 
-### 1) Loader/validator: build a compiled dispatch map
+### 1) Loader/validator: build a compiled dispatch map **[DONE]**
 
 When loading the manifest, compute:
 
@@ -248,7 +248,7 @@ Then compile:
 
 This is basically turning `manifest.routing.events` into an executable plan, but with full type info.
 
-### 2) Validation: enforce the lock-in rules
+### 2) Validation: enforce the lock-in rules **[PARTIAL]**
 
 In the validator (what you called `validate.rs`), add:
 
@@ -264,7 +264,7 @@ Fail the world load with a precise diagnostic:
 
 This is the critical piece that makes misconfig impossible.
 
-### 3) Dispatch: wrap on delivery
+### 3) Dispatch: wrap on delivery **[DONE]**
 
 In `world.rs route_event` (your mention), use `dispatch_table[E]`:
 
@@ -274,13 +274,13 @@ For each target:
 * wrap `value_cbor(E)` into `value_cbor(F)` if needed
 * invoke reducer with ABI event bytes = canonical CBOR of F
 
-### 4) Plans: change `raise_event` to publish (schema, value)
+### 4) Plans: change `raise_event` to publish (schema, value) **[PENDING]**
 
 In `plan.rs` (your mention), change `raise_event` so it canonicalizes `value` against the explicit `event` schema (not reducer ABI). This matches the AIR “event payload normalization” model. 
 
 Then append a DomainEvent (schema, bytes, maybe key) and let routing deliver.
 
-### 5) Tooling/fixtures
+### 5) Tooling/fixtures **[PENDING]**
 
 Anywhere that assumed “a reducer has exactly one event schema” should be updated to treat `defmodule.abi.reducer.event` as a family:
 
@@ -291,7 +291,7 @@ The effect catalog already defines which effects are reducer-origin scoped.
 
 ---
 
-## Spec/doc updates I would make
+## Spec/doc updates I would make **[PENDING]**
 
 1. **03-air.md**: make the routing/ABI relationship explicit and normative (validator rule). 
 2. **04-reducers.md**: clarify that reducers receive their declared event family, and the kernel wraps bus events into that family. 

--- a/roadmap/v0.5-upgrade/p1-event-dispatch.md
+++ b/roadmap/v0.5-upgrade/p1-event-dispatch.md
@@ -278,7 +278,7 @@ In `plan.rs` (your mention), change `raise_event` so it canonicalizes `value` ag
 
 Then append a DomainEvent (schema, bytes, maybe key) and let routing deliver.
 
-### 5) Tooling/fixtures **[PENDING]**
+### 5) Tooling/fixtures **[DONE]**
 
 Anywhere that assumed “a reducer has exactly one event schema” should be updated to treat `defmodule.abi.reducer.event` as a family:
 

--- a/roadmap/v0.5-upgrade/p1-event-dispatch.md
+++ b/roadmap/v0.5-upgrade/p1-event-dispatch.md
@@ -93,7 +93,7 @@ Notes:
 
 This alone prevents your current inconsistency class.
 
-### Rule B — Event-family schema shape (make it machine-checkable) **[PENDING]**
+### Rule B — Event-family schema shape (make it machine-checkable) **[DONE]**
 
 To keep conversion deterministic and tooling-friendly, constrain event families:
 
@@ -105,7 +105,7 @@ To keep conversion deterministic and tooling-friendly, constrain event families:
 
 This is a purely semantic validation on top of the JSON Schema shape system.  
 
-### Rule C — Keying must be coherent **[PENDING]**
+### Rule C — Keying must be coherent **[DONE]**
 
 You already have `key_field` on routing entries for keyed reducers (cells) and mention kernel validation around key usage.  
 

--- a/roadmap/vX-future/p3-plans-v1.1.md
+++ b/roadmap/vX-future/p3-plans-v1.1.md
@@ -583,8 +583,8 @@ receipt: {
     {
       "id": "on_success",
       "op": "raise_event",
-      "reducer": "com.acme/OrderSM@1",
-      "event": {
+      "event": "com.acme/OrderEvent@1",
+      "value": {
         "record": {
           "order_id": { "ref": "@plan.input.order_id" },
           "txn_id": { "ref": "@var:charge_result.Ok.txn_id" }
@@ -594,8 +594,8 @@ receipt: {
     {
       "id": "on_error",
       "op": "raise_event",
-      "reducer": "com.acme/OrderSM@1",
-      "event": {
+      "event": "com.acme/OrderEvent@1",
+      "value": {
         "record": {
           "order_id": { "ref": "@plan.input.order_id" },
           "error": { "ref": "@var:charge_result.Error.message" }
@@ -689,8 +689,8 @@ receipt: {
     {
       "id": "publish",
       "op": "raise_event",
-      "reducer": "com.acme/ReportSM@1",
-      "event": {
+      "event": "com.acme/ReportEvent@1",
+      "value": {
         "record": {
           "report": { "ref": "@var:report" }
         }
@@ -761,14 +761,14 @@ receipt: {
     {
       "id": "handle_success",
       "op": "raise_event",
-      "reducer": "com.acme/WorkSM@1",
-      "event": { "comment": "child succeeded before timeout" }
+      "event": "com.acme/WorkEvent@1",
+      "value": { "comment": "child succeeded before timeout" }
     },
     {
       "id": "handle_timeout",
       "op": "raise_event",
-      "reducer": "com.acme/WorkSM@1",
-      "event": { "comment": "work timed out" }
+      "event": "com.acme/WorkEvent@1",
+      "value": { "comment": "work timed out" }
     },
     { "id": "done", "op": "end" }
   ],

--- a/spec/03-air.md
+++ b/spec/03-air.md
@@ -102,7 +102,7 @@ When hashing a typed value (plan IO, cap params, etc.), always bind the **schema
 
 DomainEvents and ReceiptEvents are treated exactly like effect params:
 
-- **Ingress rule**: Every event payload is decoded against its declared `defschema` (from reducer ABI, trigger/routing entry, or built-in receipt schema), validated, canonicalized, and re-encoded as canonical CBOR. If validation fails, the event is rejected.
+- **Ingress rule**: Every event payload is decoded against its declared `defschema` (from reducer ABI for reducer delivery, trigger entry for plan starts, or built-in receipt schema when synthesizing receipts), validated, canonicalized, and re-encoded as canonical CBOR. If validation fails, the event is rejected. For reducer micro-effect receipts, the kernel **wraps** the receipt payload into the reducer’s ABI event schema before routing and journal append.
 - **Journal rule**: The journal stores and replays only these canonical bytes; replay never rewrites payloads.
 - **Routing/correlation**: Key extraction for routed/correlated events uses the schema-aware decoded value (not ExprValue tagging) and validates against the reducer’s `key_schema`.
 - **Sources**: Reducer-emitted DomainEvents, plan-raised events, adapter receipts synthesized as events, and externally injected/CLI events all flow through the same normalizer.
@@ -135,7 +135,7 @@ The manifest is the root catalog of a world's control plane. It lists all schema
 
 ### Rules
 
-Names must be unique per kind; all hashes must exist in the store. `air_version` is **required**; v1 manifests must set it to `"1"`. Supplying an unknown version or omitting the field is a validation error. `routing.events` maps DomainEvents on the bus to reducers; `routing.inboxes` maps external adapter inboxes (e.g., `http.inbox:contact_form`) to reducers for messages that skip the DomainEvent bus. For keyed reducers, include `key_field` to tell the kernel where to extract the key from the event payload (validated against the reducer's `key_schema`). The `triggers` array maps DomainIntent events to plans: when a reducer emits an event matching a trigger's schema, the kernel starts the referenced plan with that event as input; a trigger's optional `correlate_by` copies that field into the run context for later `await_event` filters. The `effects` list is the authoritative catalog of effect kinds for this world. **List every schema/effect your world uses**; built-ins are no longer auto-included. Tooling may still fill the canonical hash for built-ins when the name is present without a hash.
+Names must be unique per kind; all hashes must exist in the store. `air_version` is **required**; v1 manifests must set it to `"1"`. Supplying an unknown version or omitting the field is a validation error. `routing.events` maps DomainEvents on the bus to reducers; **the routed schema must equal the reducer’s `defmodule.abi.reducer.event`** (use a variant schema to accept multiple event shapes, including receipts). `routing.inboxes` maps external adapter inboxes (e.g., `http.inbox:contact_form`) to reducers for messages that skip the DomainEvent bus. For keyed reducers, include `key_field` to tell the kernel where to extract the key from the event payload (validated against the reducer's `key_schema`); when the event schema is a variant, `key_field` typically targets the wrapped value (e.g., `$value.note_id`). The `triggers` array maps DomainIntent events to plans: when a reducer emits an event matching a trigger's schema, the kernel starts the referenced plan with that event as input; a trigger's optional `correlate_by` copies that field into the run context for later `await_event` filters (for variant inputs, use `$value.<field>`). The `effects` list is the authoritative catalog of effect kinds for this world. **List every schema/effect your world uses**; built-ins are no longer auto-included. Tooling may still fill the canonical hash for built-ins when the name is present without a hash.
 
 See: spec/schemas/manifest.schema.json
 
@@ -256,7 +256,7 @@ Built-in capability types paired with these effects (v1): `http.out`, `blob`, `t
 
 ### Built-in reducer receipt events
 
-Reducers that emit micro-effects rely on the kernel to translate adapter receipts into typed DomainEvents. AIR v1 reserves these `defschema` names so manifests can declare routing and reducers can count on stable payloads:
+Reducers that emit micro-effects rely on the kernel to translate adapter receipts into typed DomainEvents. AIR v1 reserves these `defschema` names so reducers can include them in their **ABI event variants** and count on stable payloads:
 
 | Schema | Purpose | Fields |
 | --- | --- | --- |
@@ -264,7 +264,7 @@ Reducers that emit micro-effects rely on the kernel to translate adapter receipt
 | **`sys/BlobPutResult@1`** | Delivery of a `blob.put` receipt to the reducer. | `intent_hash:hash`, `reducer:text` (Name format), `effect_kind:text`, `adapter_id:text`, `status:"ok" \| "error" \| "timeout"`, `requested:sys/BlobPutParams@1`, `receipt:sys/BlobPutReceipt@1`, `cost_cents?:nat`, `signature:bytes` |
 | **`sys/BlobGetResult@1`** | Delivery of a `blob.get` receipt to the reducer. | `intent_hash:hash`, `reducer:text` (Name format), `effect_kind:text`, `adapter_id:text`, `status:"ok" \| "error" \| "timeout"`, `requested:sys/BlobGetParams@1`, `receipt:sys/BlobGetReceipt@1`, `cost_cents?:nat`, `signature:bytes` |
 
-Reducers should add routing entries for these schemas (e.g., `routing.events[].event = sys/TimerFired@1`). Plans typically raise domain-specific result events instead of consuming these `sys/*` receipts. The shared `cost_cents` and `signature` fields exist today so future policy/budget enforcement can trust the same structures without changing reducer code.
+Reducers should **reference these schemas from their ABI event variant** (e.g., `TimerEvent.Fired -> sys/TimerFired@1`) and route only the reducer’s ABI event schema. The kernel wraps receipt payloads into that variant before routing. Plans typically raise domain-specific result events instead of consuming these `sys/*` receipts. The shared `cost_cents` and `signature` fields exist today so future policy/budget enforcement can trust the same structures without changing reducer code.
 
 Canonical JSON definitions for these schemas (plus their parameter/receipt companions) live in `spec/defs/builtin-schemas.air.json` so manifests can hash and reference them directly.
 

--- a/spec/04-reducers.md
+++ b/spec/04-reducers.md
@@ -261,8 +261,8 @@ Note: This example uses v1 authoring sugar. The `params` and `event` fields acce
     {
       "id": "notify_reducer",
       "op": "raise_event",
-      "reducer": "com.acme/OrderSM@1",
-      "event": {
+      "event": "com.acme/OrderEvent@1",
+      "value": {
         "record": {
           "order_id": {"ref": "@plan.input.order_id"},
           "success": {

--- a/spec/04-reducers.md
+++ b/spec/04-reducers.md
@@ -84,7 +84,7 @@ Reducers consume two kinds of events:
 
 **DomainEvent**: Business events and intents. Produced by other reducers or plans via `raise_event`. Versioned by schema Name.
 
-**ReceiptEvent**: Adapter receipts converted to events by the kernel for micro-effects (e.g., `TimerFired` for `timer.set`). For complex external work, plans raise result DomainEvents instead of relying on raw receipts. Correlate using stable fields in your events/effect params (e.g., a key like `order_id` or an idempotency key). In v1.1 Cells, this key becomes a first-class route; see spec/06-cells.md.
+**ReceiptEvent**: Adapter receipts converted to events by the kernel for micro-effects (e.g., `TimerFired` for `timer.set`). These are **wrapped into the reducer’s ABI event variant** before routing, so reducers should include the built-in receipt schemas as variant arms. If a reducer emits a micro-effect, its ABI event schema must either be that receipt schema itself or a variant with a `ref` to it. For complex external work, plans raise result DomainEvents instead of relying on raw receipts. Correlate using stable fields in your events/effect params (e.g., a key like `order_id` or an idempotency key). In v1.1 Cells, this key becomes a first-class route; see spec/06-cells.md.
 
 **Important**: Do not embed `$schema` fields inside reducer event payloads. The kernel determines schemas from manifest routing and capability bindings; self-describing payloads are rejected.
 
@@ -311,7 +311,7 @@ This cycle keeps domain logic in reducers and external effects in plans. The pla
 ## ReceiptEvent And Correlation
 
 - ReceiptEvent envelope (conceptual): `{ intent_hash, effect_kind, adapter_id, status, receipt: <EffectReceiptValue> }`.
-  - For micro-effects (timer, blob), the kernel may convert receipts into standard domain events (e.g., `sys/TimerFired@1`).
+  - For micro-effects (timer, blob), the kernel converts receipts into standard payloads (`sys/TimerFired@1`, `sys/BlobPutResult@1`, …) and **wraps them into the reducer’s ABI event variant** before routing.
   - For complex effects (payments/email/http/llm), prefer plans to raise explicit result DomainEvents instead of relying on raw receipts.
 - Correlation: include stable domain ids in effect params (e.g., `order_id` or idempotency keys). Reducers match on those fields in events.
 

--- a/spec/06-cells.md
+++ b/spec/06-cells.md
@@ -18,12 +18,12 @@ Status: **implemented** (kernel/storage/control). Cells make many instances of t
 
 ## Manifest & AIR hooks
 - `defmodule.key_schema` documents the key type when routed as keyed.
-- `manifest.routing.events[].key_field` marks routed events whose value field contains the key to target a cell: `{ event, reducer, key_field }`.
+- `manifest.routing.events[].key_field` marks routed events whose value field contains the key to target a cell: `{ event, reducer, key_field }`. For variant event schemas, `key_field` should typically point into the wrapped value (e.g., `$value.note_id`).
 - Plan `raise_event` step gains `key: Expr`; required when targeting a keyed reducer.
 - Triggers may set `correlate_by` so runs inherit a key for later `await_event` filters.
 
 ## Routing, Mailboxes, Scheduling
-- On ingest, kernel extracts `key = event.value[key_field]` (validated against `key_schema`) and targets `(reducer,key)`.
+- On ingest, kernel extracts `key = event.value[key_field]` (validated against `key_schema`) and targets `(reducer,key)`. For variant payloads, the canonical wrapper is `{"$tag": "...", "$value": ...}` so the key path is usually `$value.<field>`.
 - If the cell is missing, kernel calls reducer with `state=null` (creation). `state=null` on output deletes it.
 - Each cell has its own mailbox for DomainEvents and ReceiptEvents; delivery appends to the journal and marks the cell ready.
 - Scheduler uses fair round-robin across ready cells and plan runs: one step per tick, preserving determinism.

--- a/spec/06-cells.md
+++ b/spec/06-cells.md
@@ -19,7 +19,7 @@ Status: **implemented** (kernel/storage/control). Cells make many instances of t
 ## Manifest & AIR hooks
 - `defmodule.key_schema` documents the key type when routed as keyed.
 - `manifest.routing.events[].key_field` marks routed events whose value field contains the key to target a cell: `{ event, reducer, key_field }`. For variant event schemas, `key_field` should typically point into the wrapped value (e.g., `$value.note_id`).
-- Plan `raise_event` step gains `key: Expr`; required when targeting a keyed reducer.
+- Plan `raise_event` publishes bus events; keyed routing derives the target key via `key_field` on the routing entry.
 - Triggers may set `correlate_by` so runs inherit a key for later `await_event` filters.
 
 ## Routing, Mailboxes, Scheduling

--- a/spec/06-cells.md
+++ b/spec/06-cells.md
@@ -22,6 +22,14 @@ Status: **implemented** (kernel/storage/control). Cells make many instances of t
 - Plan `raise_event` publishes bus events; keyed routing derives the target key via `key_field` on the routing entry.
 - Triggers may set `correlate_by` so runs inherit a key for later `await_event` filters.
 
+### Future: explicit key override (v1.1+ option)
+
+If we add an explicit key override (e.g., envelope key or a future plan field), it should be **strictly typed and unambiguous**:
+
+- Allowed only when **all routing targets for the event schema share the same `key_schema`**.
+- The provided key must **typecheck to `key_schema`** and **match** any key derived from `key_field` when present.
+- The payload‑derived key remains the source of truth unless an explicit “key‑only route” mode is introduced.
+
 ## Routing, Mailboxes, Scheduling
 - On ingest, kernel extracts `key = event.value[key_field]` (validated against `key_schema`) and targets `(reducer,key)`. For variant payloads, the canonical wrapper is `{"$tag": "...", "$value": ...}` so the key path is usually `$value.<field>`.
 - If the cell is missing, kernel calls reducer with `state=null` (creation). `state=null` on output deletes it.

--- a/spec/schemas/defplan.schema.json
+++ b/spec/schemas/defplan.schema.json
@@ -86,11 +86,10 @@
           "properties": {
             "id": { "$ref": "common.schema.json#/$defs/StepId" },
             "op": { "const": "raise_event" },
-            "reducer": { "$ref": "common.schema.json#/$defs/Name" },
-            "event": { "$ref": "common.schema.json#/$defs/ExprOrValue" },
-            "key": { "$ref": "common.schema.json#/$defs/Expr" }
+            "event": { "$ref": "common.schema.json#/$defs/SchemaRef" },
+            "value": { "$ref": "common.schema.json#/$defs/ExprOrValue" }
           },
-          "required": ["op","reducer","event"],
+          "required": ["op","event","value"],
           "additionalProperties": false
         }
       ]


### PR DESCRIPTION
## Make routing *strictly type-checked* against the reducer’s declared event ABI, and have the kernel **wrap/convert** bus events into the reducer’s **event-family** schema at dispatch time.

Concretely:

* The journal/bus carries **DomainEvents** as: **(schema_name, canonical_value_bytes, optional_key)**. This matches the AIR “journal invariant” model: *events are canonicalized against the schema they claim* and the journal stores only canonical bytes. 
* `manifest.routing.events` remains the **wiring table** (who gets what).  
* `defmodule.abi.reducer.event` becomes what it always *wanted* to be: the reducer’s **event-family** schema (one schema), but typically a **variant of refs** to multiple event schemas (domain + receipt).  
* The kernel **must** enforce at load/validation time that every routing entry is compatible with the reducer’s event family, and at runtime it **must never** deliver an event the reducer can’t decode according to its ABI.
* Routing may target **either the bus schema E or the reducer family schema F**. If the route uses F directly, dispatch is identity (no wrapping).

This resolves your “Purpose vs routing” tension by turning it into a clean two-layer model:

* **ABI** answers: “What can this reducer decode?” (`defmodule.abi.reducer.event`)
* **Routing** answers: “Which events are actually delivered?” (`manifest.routing.events`)

…and the validator ensures they never disagree.